### PR TITLE
Fix out of bounds access

### DIFF
--- a/src/dwarfs.cpp
+++ b/src/dwarfs.cpp
@@ -380,7 +380,7 @@ void op_readdir(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
         std::vector<char> buf(size);
         size_t written = 0;
 
-        while (off < lastoff) {
+        while (off < lastoff && written < size) {
           auto res = userdata->fs.readdir(*dir, off);
           assert(res);
 


### PR DESCRIPTION
In function `op_readdir()` in cases when variable `written` is equal to `buf.size()` the expression `&buf[written]` accesses out of bounds data. This commit fixes that.

Discovered because when building packages for Arch Linux `CXXFLAGS` contains `-Wp,-D_GLIBCXX_ASSERTIONS` [by default](https://github.com/archlinux/svntogit-packages/blob/d0fd43ecb395923de4abf70d66d5086c348e0509/pacman/repos/core-x86_64/makepkg.conf#L41-L44), which caused crashes when trying to access the mounted filesystem. Here is an example.
```
/usr/include/c++/12.2.0/bits/stl_vector.h:1123: constexpr std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = char; _Alloc = std::allocator<char>; reference = char&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
*** Aborted at 1662932620 (Unix time, try 'date -d @1662932620') ***
*** Signal 6 (SIGABRT) (0x3e80000a787) received by PID 42887 (pthread TID 0x7fcbd61fe6c0) (linux TID 42896) (maybe from PID 42887, UID 1000) (code: -6), stack trace: ***
    @ 0000000000000000 (unknown)
    @ 0000000000000000 (unknown)
    @ 0000000000000000 (unknown)
    @ 0000000000038957 gsignal
    @ 000000000002253c abort
    @ 00000000000d2111 std::__glibcxx_assert_fail(char const*, int, char const*, char const*)
                       /usr/src/debug/gcc/libstdc++-v3/src/c++11/debug.cc:60
    @ 0000000000000000 (unknown)
    @ 0000000000000000 (unknown)
    @ 0000000000000000 (unknown)
    @ 0000000000000000 (unknown)
    @ 0000000000000000 (unknown)
    @ 0000000000000000 (unknown)
```