### PR TITLE
Add early abort compression option in mkdwarfs

### DIFF
--- a/src/dwarfs/block_compressor.cpp
+++ b/src/dwarfs/block_compressor.cpp
@@ -39,6 +39,15 @@ block_compressor::block_compressor(const std::string& spec) {
   impl_ = compression_registry::instance().make_compressor(spec);
 }
 
+block_compressor::block_compressor(const std::string& spec,
+                                   const std::string& early_abort_spec) {
+  impl_ = compression_registry::instance().make_compressor(spec);
+  if (!early_abort_spec.empty() && early_abort_spec != "null") {
+    early_abort_impl_ =
+      compression_registry::instance().make_compressor(early_abort_spec);
+  }
+}
+
 block_decompressor::block_decompressor(compression_type type,
                                        const uint8_t* data, size_t size,
                                        std::vector<uint8_t>& target) {


### PR DESCRIPTION
Implement an early abort option in mkdwarfs for incompressible data blocks. This feature introduces a new command line option, --early-abort-compression, allowing users to specify a quick compression method for determining block compressibility. The feature is designed to save computational resources when normal compression is unlikely to yield better results.

This addresses feature request https://github.com/mhx/dwarfs/issues/136.