### PR TITLE
Fixed cmake_minimum_required directive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,10 @@
 # dwarfs.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+cmake_minimum_required(VERSION 3.25.0)
+
 project(dwarfs)
 include(ExternalProject)
-
-cmake_minimum_required(VERSION 3.24.0)
 
 include(CheckCXXSourceCompiles)
 


### PR DESCRIPTION
Hi, @mhx 

Thank you the great tool.
A small improvement proposal:

- ```cmake_minimum_required``` shall preceed ```project```   Otherwise cmake generates very long and annoying warning
- ```add_subdirectory(folly EXCLUDE_FROM_ALL SYSTEM)``` actually requires cmake 3.25, not 3.24

Thank you

cc: @ronaldtse
This is a contribution from [Tebako](https://www.tebako.org) ([GitHub](https://github.com/tamatebako)), a product of [Ribose](https://www.ribose.com) ([GitHub](https://github.com/riboseinc)). 