### PR TITLE
Fixed MSVC issues with /MT(d) flag propagation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,14 @@
 # dwarfs.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+cmake_minimum_required(VERSION 3.25.0)
+
+# Enable CMAKE_MSVC_RUNTIME_LIBRARY
+cmake_policy(SET CMP0091 NEW)
+
 project(dwarfs)
 
 include(ExternalProject)
-
-cmake_minimum_required(VERSION 3.25.0)
 
 include(CheckCXXSourceCompiles)
 
@@ -95,6 +98,8 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   add_compile_options(/Zc:__cplusplus /utf-8 /wd4267 /wd4244 /wd5219)
+  # Apply /MT or /MTd  (multithread, static version of the run-time library)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
@@ -244,7 +249,6 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   foreach(CompilerFlag CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE)
-    string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
     string(REPLACE "/RTC1" "" ${CompilerFlag} "${${CompilerFlag}}")
   endforeach()
 


### PR DESCRIPTION
There was an issue with the code that set static multithreaded runtime
```
string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
```
For some reason it worked with misplaced ```cmake_minimum_required``` but did not propagate changed flags to subprojects. 

If I use ```set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")``` I can put ```cmake_minimum_required``` to the top. 

I can build Windows version locally with this change; hope it will work on your self-hosted runners as well.

Thank you

cc: @ronaldtse
This is a contribution from [Tebako](https://www.tebako.org) ([GitHub](https://github.com/tamatebako)), a product of [Ribose](https://www.ribose.com) ([GitHub](https://github.com/riboseinc)). 