### PR TITLE
fix: support for upcoming Boost 1.87.0

### DIFF
--- a/src/tool/pager.cpp
+++ b/src/tool/pager.cpp
@@ -23,7 +23,7 @@
 #include <string_view>
 #include <vector>
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/process.hpp>
 
 #include <dwarfs/os_access.h>
@@ -79,7 +79,7 @@ std::optional<pager_program> find_pager_program(os_access const& os) {
 }
 
 void show_in_pager(pager_program const& pager, std::string text) {
-  boost::asio::io_service ios;
+  boost::asio::io_context ios;
   bp::child proc(pager.name.wstring(), bp::args(pager.args),
                  bp::std_in =
                      boost::asio::const_buffer(text.data(), text.size()),

--- a/test/tools_test.cpp
+++ b/test/tools_test.cpp
@@ -45,7 +45,7 @@
 #endif
 #endif
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/process.hpp>
 
 #include <fmt/format.h>
@@ -360,7 +360,7 @@ class subprocess {
       : subprocess(nullptr, prog, std::forward<Args>(args)...) {}
 
   template <subprocess_arg... Args>
-  subprocess(boost::asio::io_service& ios, std::filesystem::path const& prog,
+  subprocess(boost::asio::io_context& ios, std::filesystem::path const& prog,
              Args&&... args)
       : subprocess(&ios, prog, std::forward<Args>(args)...) {}
 
@@ -382,7 +382,7 @@ class subprocess {
 
   void run() {
     if (!ios_) {
-      throw std::runtime_error("processes with external io_service must be run "
+      throw std::runtime_error("processes with external io_context must be run "
                                "externally and then waited for");
     }
     ios_->run();
@@ -450,7 +450,7 @@ class subprocess {
 
  private:
   template <subprocess_arg... Args>
-  subprocess(boost::asio::io_service* ios, std::filesystem::path const& prog,
+  subprocess(boost::asio::io_context* ios, std::filesystem::path const& prog,
              Args&&... args)
       : prog_{prog} {
     (append_arg(cmdline_, std::forward<Args>(args)), ...);
@@ -458,7 +458,7 @@ class subprocess {
     ignore_sigpipe();
 
     if (!ios) {
-      ios_ = std::make_unique<boost::asio::io_service>();
+      ios_ = std::make_unique<boost::asio::io_context>();
       ios = ios_.get();
     }
 
@@ -492,7 +492,7 @@ class subprocess {
   }
 
   bp::child c_;
-  std::unique_ptr<boost::asio::io_service> ios_;
+  std::unique_ptr<boost::asio::io_context> ios_;
   std::future<std::string> out_;
   std::future<std::string> err_;
   std::string outs_;


### PR DESCRIPTION
io_service was deprecated and replaced by io_context in 1.66.0[^1]. The upcoming Boost 1.87.0 will remove the deprecated API[^2].

[^1]: https://github.com/boostorg/asio/commit/b60e92b13ef68dfbb9af180d76eae41d22e19356
[^2]: https://github.com/boostorg/asio/commit/ec0908c562102915423d8bd7aefd3079efbb6c86

---

`BOOST_REQUIRED_VERSION` is 1.67.0 so io_context should be available https://www.boost.org/doc/libs/1_67_0/doc/html/boost_asio/net_ts.html

I didn't change variable names for just the minimum diff needed to compile, but could modify those to `ioc` if preferred.