### PR TITLE
Fix shared library option and SO versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ project(dwarfs LANGUAGES CXX C)
 include(ExternalProject)
 include(CheckCXXSourceCompiles)
 
+option(BUILD_SHARED_LIBS "build static libs unless asked" OFF)
 option(WITH_LIBDWARFS "build with libdwarfs" ON)
 option(WITH_TOOLS "build with tools" ON)
 option(WITH_FUSE_DRIVER "build with FUSE driver" ON)

--- a/cmake/libdwarfs.cmake
+++ b/cmake/libdwarfs.cmake
@@ -286,6 +286,7 @@ list(APPEND LIBDWARFS_OBJECT_TARGETS
 if(NOT STATIC_BUILD_DO_NOT_USE)
   foreach(tgt ${LIBDWARFS_TARGETS})
     set_target_properties(${tgt} PROPERTIES VERSION ${PRJ_VERSION_MAJOR}.${PRJ_VERSION_MINOR}.${PRJ_VERSION_PATCH})
+    set_target_properties(${tgt} PROPERTIES SOVERSION ${PRJ_VERSION_MAJOR})
   endforeach()
 
   include(CMakePackageConfigHelpers)


### PR DESCRIPTION
Add minor cmake fixes to allow building shared libraries without the need to patch CMakeLists.txt and standardize the shared library versioning a little.

- cmake builtin BUILD_SHARED_LIBRARY cannot be set externally unless it was defined first. Define it in a default of "static" to allow builders to call `cmake -DBUILD_SHARED_LIBRARY=ON` if they want shared libraries instead.

- Add SOVERSION definition to allow cmake to name the shared libraries using their API version, e.g.
    * SONAME libdwarfs_common.so.0
 
    instead of

    * SONAME libdwarfs_common.so
 
  This also produces the symlink 'lib*.so.0' in addition to the usual 'lib*.so' one. This behaviour allows programs to link with SONAME '*.so.0' through their `NEEDED` section and also find it at runtime through the extra symlink.