### PR TITLE
Move dwarfs/dwarfs2 to /bin from /sbin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,7 @@ if(WITH_FUSE_DRIVER)
   endif()
 
   if(FUSE_FOUND AND (NOT APPLE) AND (WITH_LEGACY_FUSE OR NOT FUSE3_FOUND))
-    add_library(dwarfs2_main tools/src/dwarfs_main.cpp)
+    add_library(dwarfs2_main OBJECT tools/src/dwarfs_main.cpp)
     target_compile_definitions(dwarfs2_main PRIVATE _FILE_OFFSET_BITS=64
                                                     FUSE_USE_VERSION=29)
     target_link_libraries(dwarfs2_main PRIVATE PkgConfig::FUSE)


### PR DESCRIPTION
Change installation location of dwarfs/dwarfs2 and contents of mount.dwarfs/mount.dwarfs2 symlinks.
This allows dwarfs to be found in most users' PATH, and matches the manpage dwarfs(1) section.

In addition, a tiny tiny fix to dwarfs2 when BUILD_SHARED_LIBS=ON as it was missing its "dwarfs2_main" object and went looking for libdwarfs2_main.so.

Compile-tested with WITH_LEGACY_FUSE=OFF and WITH_LEGACY_FUSE=ON
```
    build/install/bin
    ├── dwarfs
    ├── dwarfsck
    ├── dwarfsextract
    └── mkdwarfs
    build/install/sbin
    └── mount.dwarfs -> ../bin/dwarfs

    buildl/install/bin
    ├── dwarfs
    ├── dwarfs2
    ├── dwarfsck
    ├── dwarfsextract
    └── mkdwarfs
    buildl/install/sbin
    ├── mount.dwarfs -> ../bin/dwarfs
    └── mount.dwarfs2 -> ../bin/dwarfs2
```

Install-tested with these calls:
```
$ ls -1 /usr/{bin,sbin}/*dwarfs* 
/usr/bin/dwarfs
/usr/bin/dwarfsck
/usr/bin/dwarfsextract
/usr/bin/mkdwarfs
/usr/sbin/mount.dwarfs

$ dwarfs $fs $mntdir
$ mount -t dwarfs $fs $mntdir
$ mount -t fuse.dwarfs $fs $mntdir
$ mount.dwarfs $fs $mntdir

/etc/fstab line:
    <fs> <mntdir>  dwarfs defaults 0 0
$ mount -a
$ systemctl start $mntdir.mount
  # this ended up owned by root, probably misconfig on my part
  # But it found 'dwarfs'!
```
