### PR TITLE
Use native C++20 std::chrono instead of date

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -48,8 +48,6 @@
 #include <utf8.h>
 #endif
 
-#include <date/date.h>
-
 #include <folly/ExceptionString.h>
 #include <folly/String.h>
 #include <folly/portability/Fcntl.h>
@@ -191,7 +189,7 @@ std::chrono::system_clock::time_point parse_time_point(std::string const& str) {
   for (auto const& fmt : formats) {
     std::istringstream iss(str);
     std::chrono::system_clock::time_point tp;
-    date::from_stream(iss, fmt, tp);
+    std::chrono::from_stream(iss, fmt, tp);
     if (!iss.fail()) {
       iss.peek();
       if (iss.eof()) {


### PR DESCRIPTION
The date library, provided for example by hhdate, has been adopted in the C++20 standard into the std::chrono header.

There was only one usage of the date library in the codebase. This PR allows to drop the hhdate dependency completely.

The tests still pass with this change, but I have not performed any manual testing whatsoever (I am not familiar with dwarfs).

I prepared this since we recently dropped the hhdate library from openSUSE Tumbleweed and we are cleaning up the few remaining users of the library.