### PR TITLE
don't limit string size when dumping metadata

### DIFF
--- a/src/reader/internal/metadata_v2.cpp
+++ b/src/reader/internal/metadata_v2.cpp
@@ -1528,7 +1528,9 @@ void metadata_v2_data::dump(
   }
 
   if (opts.features.has(fsinfo_feature::schema_raw_dump)) {
-    os << ::apache::thrift::debugString(deserialize_schema(schema_)) << '\n';
+    ::apache::thrift::DebugProtocolWriter::Options opts;
+    opts.stringLengthLimit = -1;
+    os << ::apache::thrift::debugString(deserialize_schema(schema_), opts) << '\n';
   }
 
   if (opts.features.has(fsinfo_feature::metadata_details)) {
@@ -1565,7 +1567,10 @@ void metadata_v2_data::dump(
   }
 
   if (opts.features.has(fsinfo_feature::metadata_full_dump)) {
-    os << ::apache::thrift::debugString(meta_.thaw()) << '\n';
+    ::apache::thrift::DebugProtocolWriter::Options opts;
+    opts.stringLengthLimit = -1;
+
+    os << ::apache::thrift::debugString(meta_.thaw(), opts) << '\n';
   }
 
   if (opts.features.has(fsinfo_feature::directory_tree)) {


### PR DESCRIPTION
Fixes #295 

Not sure if this is the best way to do it, but it works for me.