### PR TITLE
Add shell completion for dwarfs, dwarfsck & dwarfsextract

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,15 +306,13 @@ if(WITH_TOOLS)
     install(TARGETS ${tgt} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     if(WIN32)
       install(FILES $<TARGET_PDB_FILE:${tgt}> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)
+    else()
+      install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/doc/completions/bash/${tgt}
+              DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${BASH_INSTALL_PATH})
+      install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/doc/completions/zsh/_${tgt}
+              DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${ZSH_INSTALL_PATH})
     endif()
   endforeach()
-
-  if(NOT WIN32)
-    file(GLOB SHELLCOMP_BASH_FILES ${CMAKE_CURRENT_SOURCE_DIR}/doc/completions/bash/*)
-    file(GLOB SHELLCOMP_ZSH_FILES ${CMAKE_CURRENT_SOURCE_DIR}/doc/completions/zsh/*)
-    install(FILES "${SHELLCOMP_BASH_FILES}" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${BASH_INSTALL_PATH})
-    install(FILES "${SHELLCOMP_ZSH_FILES}" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${ZSH_INSTALL_PATH})
-  endif()
 
   target_link_libraries(mkdwarfs_main PRIVATE dwarfs_reader dwarfs_writer dwarfs_rewrite)
   target_link_libraries(dwarfsck_main PRIVATE dwarfs_reader)
@@ -425,6 +423,10 @@ if(WITH_FUSE_DRIVER)
         file(CREATE_LINK \"${relative_sbindir_to_bindir}/dwarfs\"
                          \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_SBINDIR}/mount.dwarfs\"
                          SYMBOLIC)")
+      install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/doc/completions/bash/dwarfs
+              DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${BASH_INSTALL_PATH})
+      install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/doc/completions/zsh/_dwarfs
+              DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${ZSH_INSTALL_PATH})
     endif()
     list(APPEND BINARY_TARGETS dwarfs-bin)
     list(APPEND MAIN_TARGETS dwarfs_main)

--- a/doc/completions/bash/dwarfs
+++ b/doc/completions/bash/dwarfs
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+# Author: Ahmad Khalifa
+#
+# bash completion for dwarfs
+#
+# synopsis
+#   dwarfs <image.dwarfs> <mountpoint> [-o option]...
+#   dwarfs <image.dwarfs> --auto-mountpoint [-o option]...
+#
+
+__dwarfs_additional_options()
+{
+    if dwarfs -h | grep -qe ' *--man'; then
+        echo "--man"
+    fi
+}
+
+_dwarfs_completion()
+{
+    local cur prev words cword
+    _comp_initialize || return
+
+    # options that show up at any position
+    local OPTIONS_GENERAL=(
+        -d -f -o -s
+    )
+    # options that show up at first position and not followed by anything
+    local OPTIONS_GENERAL_FIRST=(
+        -h --help $(__dwarfs_additional_options)
+    )
+
+    local OPTION_ARG__owitharg=( analysis_file block_allocator blocksize cachesize
+        cache_files debuglevel decratio gid imagesize mlock offset perfmon_trace
+        perfmon preload_category readahead seq_detector tidy_interval
+        tidy_max_age tidy_strategy uid workers max_idle_threads max_threads )
+    local OPTION_ARG__onoarg=( debug clone_fd enable_nlink readonly cache_image
+        case_insensitive preload_all no_cache_files no_cache_image )
+
+    # catch option with known arguments first
+    case $prev in
+        -o )
+            _comp_compgen -- -W '"${OPTION_ARG__owitharg[@]}"' -S "="
+            _comp_compgen -a -- -W '"${OPTION_ARG__onoarg[@]}"'
+            return 0
+            ;;
+        -h | --help | --man )
+            # nothing else to add
+            return 0
+            ;;
+    esac
+
+    # count non-option args (including --a-mp as second arg)
+    local carg=1 i
+    for (( i=1; i < ${cword}; i++ )); do
+        if [[ ( ${words[i]} != -* && ${words[i-1]} != "-o" ) ||
+                ${words[i]} == "--auto-mountpoint" ]]; then
+            carg=$((carg+1))
+        fi
+    done
+
+    if [[ $carg == 2 ]]; then
+        # second arg is dir or --auto-mp
+        _comp_compgen -- -W '"--auto-mountpoint"'
+        _comp_compgen -a -- -d
+    elif [[ $cur == -* || $carg -gt 2 ]]; then
+        # cursor on an option or already have 2 args, show options only
+        _comp_compgen -- -W '"${OPTIONS_GENERAL[@]}"'
+        if [[ $carg -eq 1 ]]; then
+            _comp_compgen -a -- -W '"${OPTIONS_GENERAL_FIRST[@]}"'
+        fi
+    else
+        # show all options and dwarfs files to start
+        _comp_compgen -- -W '"${OPTIONS_GENERAL[@]}"'
+        _comp_compgen -a -- -W '"${OPTIONS_GENERAL_FIRST[@]}"'
+        _comp_compgen -a filedir dwarfs
+    fi
+
+    return 0
+} &&
+complete -F _dwarfs_completion dwarfs

--- a/doc/completions/bash/dwarfsck
+++ b/doc/completions/bash/dwarfsck
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MIT
+# Author: Ahmad Khalifa
+#
+# bash completion for dwarfsck
+#
+# synopsis
+#   dwarfsck [OPTIONS...]
+#
+
+__dwarfsck_additional_options()
+{
+    if dwarfsck -h | grep -qe ' *--man'; then
+        echo "--man"
+    fi
+}
+
+_dwarfsck_completion()
+{
+    local cur prev words cword
+    _comp_initialize || return
+
+    local OPTIONS_GENERAL=(
+        --check-integrity
+        --checksum
+        --export-metadata
+        --log-level
+        --log-with-context
+        --no-check
+        -d --detail
+        -h --help
+        -H --print-header
+        -i --input
+        -j --json
+        -l --list
+        -n --num-workers
+        -O --image-offset
+        -q --quiet
+        -v --verbose
+        $(__dwarfsck_additional_options)
+    )
+
+    local OPTION_ARG__detail=( frozen_analysis history metadata_summary version )
+    local OPTION_ARG__log_level=( error warn info verbose debug trace )
+    local OPTION_ARG_d=( ${OPTION_ARG__detail[@]} )
+    # silent, no completion
+    local OPTION_ARG_NONE=( --checksum --image-offset --num-workers -n -O )
+
+    # catch option with known arguments first
+    case $prev in
+        --checksum | --detail | --log-level | --image-offset | --num-workers | \
+        -d | -n | -O )
+            prevoption=${prev//-/_}
+            _comp_compgen -- -W '"${OPTION_ARG'$prevoption'[@]}"'
+            return 0
+            ;;
+        -i | --input)
+            _comp_compgen -a filedir dwarfs
+            return 0
+            ;;
+        --export-metadata)
+            _comp_compgen -a filedir
+            return 0
+            ;;
+    esac
+
+    # check if previous option is silent
+    if [[ $prev == -* ]]; then
+        for f in ${OPTION_ARG_NONE[@]}; do
+            [[ "$prev" = "$f" ]] && return 0
+        done
+    fi
+
+    # show all options
+    _comp_compgen -- -W '"${OPTIONS_GENERAL[@]}"'
+
+    return 0
+} &&
+complete -F _dwarfsck_completion dwarfsck

--- a/doc/completions/bash/dwarfsextract
+++ b/doc/completions/bash/dwarfsextract
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MIT
+# Author: Ahmad Khalifa
+#
+# bash completion for dwarfsextract
+#
+# synopsis
+#   dwarfsextract [OPTIONS...]
+#
+
+__dwarfsextract_additional_options()
+{
+    if dwarfsextract -h | grep -qe ' *--man'; then
+        echo "--man"
+    fi
+}
+
+_dwarfsextract_completion()
+{
+    local cur prev words cword
+    _comp_initialize || return
+
+    local OPTIONS_GENERAL=(
+        --continue-on-error
+        --disable-integrity-check
+        --format-filters
+        --format-options
+        --log-level
+        --log-with-context
+        --pattern
+        --perfmon
+        --perfmon-trace
+        --stdout-progress
+        -f --format
+        -h --help
+        -i --input
+        -n --num-workers
+        -O --image-offset
+        -o --output
+        -s --cache-size
+        $(__dwarfsextract_additional_options)
+    )
+
+    local OPTION_ARG__log_level=( error warn info verbose debug trace )
+    # silent, no completion
+    local OPTION_ARG_NONE=( --cache-size -f --format --format-filters \
+        --format-options --image-offset --pattern --perfmon -n --num-workers \
+        -O -s  )
+
+    # catch option with known arguments first
+    case $prev in
+        --log-level)
+            prevoption=${prev//-/_}
+            _comp_compgen -- -W '"${OPTION_ARG'$prevoption'[@]}"'
+            return 0
+            ;;
+        -i | --input)
+            _comp_compgen -a filedir dwarfs
+            return 0
+            ;;
+        --perfmon-trace | -o | --output)
+            _comp_compgen -a filedir
+            return 0
+            ;;
+    esac
+
+    # check if previous option is silent
+    if [[ $prev == -* ]]; then
+        for f in ${OPTION_ARG_NONE[@]}; do
+            [[ "$prev" = "$f" ]] && return 0
+        done
+    fi
+
+    # show all options
+    _comp_compgen -- -W '"${OPTIONS_GENERAL[@]}"'
+
+    return 0
+} &&
+complete -F _dwarfsextract_completion dwarfsextract

--- a/doc/completions/bash/mkdwarfs
+++ b/doc/completions/bash/mkdwarfs
@@ -23,7 +23,7 @@ __mkdwarfs_list_comp_algos()
 
 __mkdwarfs_additional_options()
 {
-    if [[ "$(mkdwarfs -h | grep -e ' *--man')" ]]; then
+    if mkdwarfs -h | grep -qe ' *--man'; then
         echo "--man"
     fi
 }

--- a/doc/completions/zsh/_dwarfs
+++ b/doc/completions/zsh/_dwarfs
@@ -1,0 +1,77 @@
+#compdef dwarfs
+#
+# SPDX-License-Identifier: MIT
+# Author: Ahmad Khalifa
+#
+# zsh completion for dwarfs
+#
+# synopsis
+#   dwarfs <image.dwarfs> <mountpoint> [-o option]...
+#   dwarfs <image.dwarfs> --auto-mountpoint [-o option]...
+#
+
+local context state line ret=1
+
+__dwarfs_disable_man()
+{
+    if ! dwarfs -h | grep -qe ' *--man'; then
+        echo -n "!"
+    fi
+}
+
+__dwarfs_mount_point()
+{
+    # complete arg 2 with dirs and auto-mp option
+    _files -/
+    compadd "$@" -- "--auto-mountpoint"
+}
+
+_arguments -S \
+    + "mainoptions" \
+    "(oneonly)-d[enable debug output (implies -f)]" \
+    "(oneonly)-f[foreground operation]" \
+    "(oneonly)*-o[dwarfs or fuse mount options]:option:->mount_options" \
+    "(oneonly)-s[disable multi-threaded operation]" \
+    "(oneonly)1:dwarfs image:_files -g '*.dwarfs'" \
+    "(oneonly)2:mount point:__dwarfs_mount_point" \
+    + "(oneonly)" \
+    "(mainoptions)"{-h,--help}"[output help message and exit]" \
+    "$(__dwarfs_disable_man)(mainoptions)--man[show manual page and exit]" && ret=0
+
+case "$state" in
+    mount_options)
+        _values "mount options" \
+            "analysis_file[write accessed files to this file]:filename:_files" \
+            "block_allocator[(malloc) | mmap]:" \
+            "blocksize[set file I/O block size (512K)]:" \
+            "cache_files[keep files in kernel cache]" \
+            "cache_image[keep image in kernel cache]" \
+            "cachesize[set size of block cache (512M)]:" \
+            "case_insensitive[perform case-insensitive lookups]" \
+            "clone_fd[use separate fuse device fd for each thread]" \
+            "debug[enable debug output (implies -f)]" \
+            "debuglevel[debug level]:level:(error warn info verbose debug trace)" \
+            "decratio[ratio for full decompression (0.8)]:" \
+            "enable_nlink[show correct hardlink numbers]" \
+            "gid[override group ID for file system]:" \
+            "imagesize[filesystem image size in bytes]:" \
+            "mlock[mlock mode]:" \
+            "no_cache_files[do not keep files in kernel cache]" \
+            "no_cache_image[do not keep image in kernel cache]" \
+            "offset[filesystem image offset in bytes (0)]:" \
+            "perfmon_trace[write performance monitor trace file]:filename:_files" \
+            "perfmon[enable performance monitor]:" \
+            "preload_all[preload all file system blocks]" \
+            "preload_category[preload blocks from this category]:" \
+            "readahead[set readahead size (0)]:" \
+            "readonly[show read-only file system]" \
+            "seq_detector[sequential access detector threshold (4)]:" \
+            "tidy_interval[interval for cache tidying (5m)]:" \
+            "tidy_max_age[tidy blocks after this time (10m)]:" \
+            "tidy_strategy[tidy strategy (none)|time|swap]:" \
+            "uid[override user ID for file system]:" \
+            "workers[number of worker threads (2)]:"
+        ;;
+esac
+
+return ret

--- a/doc/completions/zsh/_dwarfsck
+++ b/doc/completions/zsh/_dwarfsck
@@ -1,0 +1,40 @@
+#compdef dwarfsck
+#
+# SPDX-License-Identifier: MIT
+# Author: Ahmad Khalifa
+#
+# zsh completion for dwarfsck
+#
+# synopsis
+#   dwarfsck [OPTIONS...]
+#
+
+local context state line ret=1
+
+__dwarfsck_disable_man()
+{
+    if ! dwarfsck -h | grep -qe ' *--man'; then
+        echo -n "!"
+    fi
+}
+
+_arguments -S \
+	"--check-integrity[check integrity of each block]" \
+	"--checksum[print checksums for all files]:hashfnc:" \
+	"--export-metadata[export raw metadata as JSON to file]:filename:_files" \
+	"--log-level[log level]:level:(error warn info verbose debug trace)" \
+	"--log-with-context[enable context logging regardless of level]" \
+	"--no-check[don't even verify block checksums]" \
+	{-d,--detail}"[detail level or feature list]:level:(frozen_analysis history metadata_summary version)" \
+	{-h,--help}"[output help message and exit]" \
+	{-H,--print-header}"[print filesystem header to stdout and exit]" \
+	{-i,--input}"[input filesystem]:filename:_files -g '*.dwarfs'" \
+	{-j,--json}"[print information in JSON format]" \
+	{-l,--list}"[list all files and exit]" \
+	{-n,--num-workers=-}"[number of reader worker threads]:num:" \
+	{-O,--image-offset=-}"[filesystem image offset in bytes]:num:" \
+	{-q,--quiet}"[don't print anything unless an error occurs]" \
+	{-v,--verbose}"[produce verbose output]" \
+	"$(__dwarfsck_disable_man)--man[show manual page and exit]" && ret=0
+
+return ret

--- a/doc/completions/zsh/_dwarfsextract
+++ b/doc/completions/zsh/_dwarfsextract
@@ -1,0 +1,41 @@
+#compdef dwarfsextract
+#
+# SPDX-License-Identifier: MIT
+# Author: Ahmad Khalifa
+#
+# zsh completion for dwarfsextract
+#
+# synopsis
+#   dwarfsextract [OPTIONS...]
+#
+
+local context state line ret=1
+
+__dwarfsextract_disable_man()
+{
+    if ! dwarfsextract -h | grep -qe ' *--man'; then
+        echo -n "!"
+    fi
+}
+
+_arguments -S \
+	"--continue-on-error[continue if errors are encountered]" \
+	"--disable-integrity-check[disable file system image block integrity check (dangerous)]" \
+	"--format-filters[comma-separated libarchive format filters]:filters:" \
+	"--format-options[options for the specific libarchive format/filters]:options:" \
+	"--log-level[log level]:level:(error warn info verbose debug trace)" \
+	"--log-with-context[enable context logging regardless of level]" \
+	"--pattern[only extract files matching these patterns]:pattern:" \
+	"--perfmon[enable performance monitor]" \
+	"--perfmon-trace[write performance monitor trace file]:filename:_files" \
+	"--stdout-progress[write percentage progress to stdout]" \
+	{-f,--format}"[output format]:format:" \
+	{-h,--help}"[output help message and exit]" \
+	{-i,--input}"[input filesystem]:filename:_files -g '*.dwarfs'" \
+	{-n,--num-workers=-}"[number of reader worker threads]:num:" \
+	{-O,--image-offset=-}"[filesystem image offset in bytes]:num:" \
+	{-o,--output}"[output file or directory]:filename:_files" \
+	{-s,--cache-size}"[block cache size]:size:" \
+	"$(__dwarfsextract_disable_man)--man[show manual page and exit]" && ret=0
+
+return ret

--- a/doc/completions/zsh/_mkdwarfs
+++ b/doc/completions/zsh/_mkdwarfs
@@ -27,7 +27,7 @@ __mkdwarfs_list_comp_algos()
 
 __mkdwarfs_disable_man()
 {
-    if [[ ! "$(mkdwarfs -h | grep -e ' *--man')" ]]; then
+    if ! mkdwarfs -h | grep -qe ' *--man'; then
         echo -n "!"
     fi
 }


### PR DESCRIPTION
- Bash and Zsh completion
- Slight deviation from mkdwarfs completion in that they show options only, not options and files. And also --input now filters to .dwarfs extension only
- Switch from cmake file(GLOB) to naming the files directly so it doesn't pick up dwarfs when not built.

dwarfs on hold a bit to see if --auto-mountpoint needs to be added (which complicates the completion a bit)