### PR TITLE
Add sample desktop unmount handlers

### DIFF
--- a/data/unmount-handler.desktop
+++ b/data/unmount-handler.desktop
@@ -1,0 +1,36 @@
+# Sample desktop unmount handler
+#
+# dwarfs ships with a handler for *.dwarfs files that can mount dwarfs files
+# to a new directory next to the filesystem image. In some desktop
+# environments (KDE dolphin), there may not be an obvious way to unmount those
+# directories without opening a terminal.
+#
+# This is a sample unmount handler that attaches to **all directories**
+# and mountpoints to call unmount.
+# Since some desktop environments (Gnome Files) already have a built-in
+# Unmount action and others don't distinguish 'mountpoints' mimetype correctly,
+# this is not installed by default. It would show up for all directories and
+# would try to unmount anything (dwarfs or not, hence the name).
+#
+# While it may be harmless for normal directories, unmounting the wrong
+# directory, even as current user, not root, could still be dangerous or cause
+# undesired effects, especially if used on non-dwarfs mounts.
+#
+# How to use this?
+# 1. copy this file to ~/.local/share/applications
+#      (or globally with sudo to /usr/local/share/applications)
+# 2. update the desktop database cache for that dir
+#    $ update-desktop-database ~/.local/share/applications
+# 3. Right-click any mounted dir and Open With -> Unmount Directory
+#
+[Desktop Entry]
+Name=Unmount Directory
+TryExec=umount
+Exec=umount %f
+Icon=media-eject
+NoDisplay=true
+Terminal=false
+StartupNotify=false
+Type=Application
+Categories=Utility;
+MimeType=inode/directory;inode/mount-point;

--- a/data/unmount-servicemenu.desktop
+++ b/data/unmount-servicemenu.desktop
@@ -1,0 +1,32 @@
+# Sample unmount KDE servicemenu
+#
+# dwarfs ships with a handler for *.dwarfs files that can mount dwarfs files
+# to a new directory next to the filesystem image. Currently, KDE dolphin
+# does not have any obvious way to unmount those directories without opening
+# a terminal (as doesn't show under Remote or Devices panels).
+#
+# This is a sample service menu that attaches to **all directories**
+# and mountpoints to call unmount.
+#
+# While it may be harmless for normal directories, unmounting the wrong
+# directory, even as current user, not root, could still be dangerous or cause
+# undesired effects, especially if used on non-dwarfs mounts.
+#
+# How to use this?
+# 1. Copy this file to ~/.local/share/kio/servicemenus
+#      (or globally with sudo to /usr/share/kio/servicemenus)
+# 2. make it executable
+#    $ chmod ug+x ~/.local/share/kio/servicemenus/unmount-servicemenu.desktop
+# 2. Reopen Dolphin
+# 3. Right-click any mounted dir and click 'Unmount Directory'
+#
+[Desktop Entry]
+Type=Service
+MimeType=inode/mount-point;inode/directory;
+Icon=media-eject
+Actions=unmount
+
+[Desktop Action unmount]
+Name=Unmount Directory
+Icon=media-eject
+Exec=findmnt -n "%f" && ( umount "%f" && kdialog --msgbox "Directory unmounted OK") || kdialog --error "Directory is not a mountpoint"


### PR DESCRIPTION
I had both already, so I added a little comment on the top on how to use them.
They may need some more disclaimers or warnings and users certainly don't need both installed.

1. Generic directory handler to unmount any directory. Testable from `mimeopen --ask`. But no feedback as can't assume kdialog/zenity/etc... are installed.
2. KDE servicemenu to unmount any directory, with additional kdialog feedback and findmnt check as it can assume kdialog is installed. Only testable from live KDE system.

The desktop handler is confusingly "Open With", but shows for all desktops. While the service menu is permanently visible, but limited to KDE only (which is good, I think).

<img width="610" height="563" alt="desktop-unmount3" src="https://github.com/user-attachments/assets/521f2be8-9109-4a9f-97e3-fb0883786f90" />


PS, maybe a bug to KDE would help recognise 'fuse.dwarfs' as a 'Device'.