### PR TITLE
Fix building on Windows with non-MS STL libraries

### DIFF
--- a/src/internal/file_status_conv.cpp
+++ b/src/internal/file_status_conv.cpp
@@ -85,7 +85,7 @@ uint16_t file_status_to_mode(std::filesystem::file_status status) {
     ft = posix_file_type::block;
     break;
   case fs::file_type::directory:
-#ifdef _WIN32
+#ifdef _MSVC_STL_VERSION
   case fs::file_type::junction:
 #endif
     ft = posix_file_type::directory;

--- a/src/performance_monitor.cpp
+++ b/src/performance_monitor.cpp
@@ -37,6 +37,7 @@
 
 #ifdef _WIN32
 #include <dwarfs/portability/windows.h>
+#include <process.h>
 #else
 #include <sys/time.h>
 #endif

--- a/test/compare_directories.cpp
+++ b/test/compare_directories.cpp
@@ -47,7 +47,7 @@ constexpr sorted_array_map file_type_name{
     std::pair{fs::file_type::not_found, "not_found"sv},
     std::pair{fs::file_type::regular, "regular"sv},
     std::pair{fs::file_type::directory, "directory"sv},
-#ifdef _WIN32
+#ifdef _MSVC_STL_VERSION
     std::pair{fs::file_type::junction, "junction"sv},
 #endif
     std::pair{fs::file_type::symlink, "symlink"sv},
@@ -60,7 +60,7 @@ constexpr sorted_array_map file_type_name{
 
 bool is_directory(fs::file_type ft) {
   return ft == fs::file_type::directory
-#ifdef _WIN32
+#ifdef _MSVC_STL_VERSION
          || ft == fs::file_type::junction
 #endif
       ;


### PR DESCRIPTION
Address two compilation issues:
* `fs::file_type::junction` is non-standard and is available only in MS STL, guard it harder;
* `<process.h>` is not always pulled indirectly to `performance_monitor.cpp` when using non-MS STL, which leads to missing `getpid()` declaration, so include it explicitly.

Tested with ClangCL/LLVM and libc++.

Despite that libc++ is not shipped with the official LLVM binaries, it's fully legit to compile it manually and use natively on Windows (I've been using statically-linked libc++ in my Windows project for almost a year already).

---

I'll have one more PR for ya, it's a feature, not a bugfix one, and can make DwFS even faster in some scenarios and less bug-prone.
No rocket science there tho. I prefer to not have more than one PR per repo at a time, so it can wait (I'll polish it in meantime...).