### PR TITLE
feat: add option to use Abseil instead of parallel-hashmap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ option(WITH_ALL_BENCHMARKS "build with *all* benchmarks" OFF)
 option(WITH_FUZZ "build with fuzzing binaries" OFF)
 option(WITH_MAN_OPTION "build with --man option" ON)
 option(ENABLE_PERFMON "enable performance monitor in all tools" ON)
+option(TRY_ENABLE_ABSEIL "use Abseil instead of parallel-hashmap" ON)
 option(TRY_ENABLE_FLAC "build with FLAC support" ON)
 option(ENABLE_RICEPP "build with RICEPP compression support" ON)
 option(TRY_ENABLE_BROTLI "build with BROTLI compression support" ON)
@@ -211,7 +212,18 @@ include(${CMAKE_SOURCE_DIR}/cmake/need_fmt.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/need_range_v3.cmake)
 
 if(WITH_LIBDWARFS)
-  include(${CMAKE_SOURCE_DIR}/cmake/need_phmap.cmake)
+  set(DWARFS_HAVE_ABSEIL OFF)
+
+  if(TRY_ENABLE_ABSEIL)
+    find_package(absl CONFIG)
+    if (absl_FOUND)
+      include(${CMAKE_SOURCE_DIR}/cmake/need_abseil.cmake)
+    endif()
+  endif()
+
+  if(NOT DWARFS_HAVE_ABSEIL)
+    include(${CMAKE_SOURCE_DIR}/cmake/need_phmap.cmake)
+  endif()
 
   find_package(Threads REQUIRED)
   find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED CONFIG
@@ -825,7 +837,7 @@ if(WITH_TESTS)
   endif()
 
   if(TARGET dwarfs_unit_tests)
-    target_link_libraries(dwarfs_unit_tests PRIVATE phmap)
+    target_link_libraries(dwarfs_unit_tests PRIVATE $<IF:${DWARFS_HAVE_ABSEIL},${DWARFS_ABSEIL_DEPS},phmap>)
   endif()
 
   if(TARGET manpage_test)
@@ -977,9 +989,13 @@ if(BUILD_FSST_MAIN)
 endif()
 
 foreach(tgt ${LIBDWARFS_TARGETS})
-  target_include_directories(${tgt} SYSTEM PRIVATE
-    $<BUILD_INTERFACE:$<TARGET_PROPERTY:phmap,INTERFACE_INCLUDE_DIRECTORIES>>
-  )
+  if(DWARFS_HAVE_ABSEIL)
+    target_link_libraries(${tgt} PUBLIC ${DWARFS_ABSEIL_DEPS})
+  else()
+    target_include_directories(${tgt} SYSTEM PRIVATE
+      $<BUILD_INTERFACE:$<TARGET_PROPERTY:phmap,INTERFACE_INCLUDE_DIRECTORIES>>
+    )
+  endif()
 endforeach()
 
 foreach(tgt ${LIBDWARFS_TARGETS} ${LIBDWARFS_OBJECT_TARGETS}

--- a/cmake/checks/abseil-version.cpp
+++ b/cmake/checks/abseil-version.cpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright (c) Marcus Holland-Moritz
+// SPDX-License-Identifier: MIT
+
+#define DWARFS_HAVE_ABSEIL
+
+#include <dwarfs/internal/btree.h>
+#include <dwarfs/internal/phmap.h>
+
+// If this template instantiation fails, it means the available Abseil version
+// doesn't have commit 4ab53949759d which we rely on.
+// Abseil LTS 20260107 and rolling builds newer than Dec 15, 2025 have it.
+static_assert(sizeof(dwarfs::internal::flat_hash_map<int, int>) > 0);
+
+int main() { return 0; }

--- a/cmake/libdwarfs.cmake
+++ b/cmake/libdwarfs.cmake
@@ -228,9 +228,15 @@ target_include_directories(dwarfs_frozen PRIVATE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/frozen>
   $<BUILD_INTERFACE:${THRIFT_GENERATED_DIR}>
 )
-target_include_directories(dwarfs_frozen SYSTEM PUBLIC
-  $<BUILD_INTERFACE:$<TARGET_PROPERTY:phmap,INTERFACE_INCLUDE_DIRECTORIES>>
-)
+
+if(DWARFS_HAVE_ABSEIL)
+  target_link_libraries(dwarfs_frozen PUBLIC ${DWARFS_ABSEIL_DEPS})
+else()
+  target_include_directories(dwarfs_frozen SYSTEM PUBLIC
+    $<BUILD_INTERFACE:$<TARGET_PROPERTY:phmap,INTERFACE_INCLUDE_DIRECTORIES>>
+  )
+endif()
+
 target_link_libraries(dwarfs_frozen PUBLIC PkgConfig::XXHASH)
 
 add_library(

--- a/cmake/need_abseil.cmake
+++ b/cmake/need_abseil.cmake
@@ -1,0 +1,48 @@
+#
+# Copyright (c) Marcus Holland-Moritz
+#
+# This file is part of dwarfs.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the “Software”), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+#
+
+# absl*.cmake don't export any variables
+find_path(absl_INCLUDE_DIR absl/container/btree_map.h)
+
+unset(DWARFS_HAVE_ABSEIL)
+
+try_compile(
+  DWARFS_HAVE_ABSEIL
+  SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/checks/abseil-version.cpp
+  CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_CURRENT_SOURCE_DIR}/include;${absl_INCLUDE_DIR};${TRY_RUN_INCLUDE_DIRECTORIES}"
+)
+
+if(DWARFS_HAVE_ABSEIL)
+  set(DWARFS_ABSEIL_DEPS
+    absl::btree
+    absl::flat_hash_map
+    absl::flat_hash_set
+    absl::node_hash_map
+    absl::node_hash_set
+  )
+else()
+  message(STATUS "Abseil version is older than the required minimum, falling back to parallel-hashmap")
+endif()

--- a/frozen/thrift/lib/cpp2/frozen/Frozen.h
+++ b/frozen/thrift/lib/cpp2/frozen/Frozen.h
@@ -30,9 +30,6 @@
 
 #include <xxhash.h>
 
-#include <parallel_hashmap/btree.h>
-#include <parallel_hashmap/phmap.h>
-
 #include <thrift/lib/cpp2/frozen/FixedSizeStringHash.h>
 #include <thrift/lib/cpp2/frozen/FrozenMacros.h>
 #include <thrift/lib/cpp2/frozen/HintTypes.h>
@@ -41,6 +38,8 @@
 #include <thrift/lib/thrift/gen-cpp-lite/frozen_types.h>
 
 #include <dwarfs/bit_view.h>
+#include <dwarfs/internal/btree.h>
+#include <dwarfs/internal/phmap.h>
 #include <dwarfs/thrift_lite/assert.h>
 #include <dwarfs/thrift_lite/demangle.h>
 #include <dwarfs/thrift_lite/utility.h>

--- a/frozen/thrift/lib/cpp2/frozen/FrozenAssociative-inl.h
+++ b/frozen/thrift/lib/cpp2/frozen/FrozenAssociative-inl.h
@@ -170,15 +170,15 @@ struct Layout<T, std::enable_if_t<IsHashSet<T>::value>>
 } // namespace apache::thrift::frozen
 
 THRIFT_DECLARE_TRAIT_TEMPLATE(IsHashMap, std::unordered_map)
-THRIFT_DECLARE_TRAIT_TEMPLATE(IsHashMap, phmap::flat_hash_map)
-THRIFT_DECLARE_TRAIT_TEMPLATE(IsHashMap, phmap::node_hash_map)
+THRIFT_DECLARE_TRAIT_TEMPLATE(IsHashMap, dwarfs::internal::flat_hash_map)
+THRIFT_DECLARE_TRAIT_TEMPLATE(IsHashMap, dwarfs::internal::node_hash_map)
 
 THRIFT_DECLARE_TRAIT_TEMPLATE(IsHashSet, std::unordered_set)
-THRIFT_DECLARE_TRAIT_TEMPLATE(IsHashSet, phmap::flat_hash_set)
-THRIFT_DECLARE_TRAIT_TEMPLATE(IsHashSet, phmap::node_hash_set)
+THRIFT_DECLARE_TRAIT_TEMPLATE(IsHashSet, dwarfs::internal::flat_hash_set)
+THRIFT_DECLARE_TRAIT_TEMPLATE(IsHashSet, dwarfs::internal::node_hash_set)
 
 THRIFT_DECLARE_TRAIT_TEMPLATE(IsOrderedMap, std::map)
-THRIFT_DECLARE_TRAIT_TEMPLATE(IsOrderedMap, phmap::btree_map)
+THRIFT_DECLARE_TRAIT_TEMPLATE(IsOrderedMap, dwarfs::internal::btree_map)
 
 THRIFT_DECLARE_TRAIT_TEMPLATE(IsOrderedSet, std::set)
-THRIFT_DECLARE_TRAIT_TEMPLATE(IsOrderedSet, phmap::btree_set)
+THRIFT_DECLARE_TRAIT_TEMPLATE(IsOrderedSet, dwarfs::internal::btree_set)

--- a/frozen/thrift/lib/cpp2/frozen/test/FrozenAssociativeTest.cpp
+++ b/frozen/thrift/lib/cpp2/frozen/test/FrozenAssociativeTest.cpp
@@ -62,7 +62,7 @@ TYPED_TEST_P(FrozenMapBasic, Basic) {
 
 REGISTER_TYPED_TEST_SUITE_P(FrozenMapBasic, Basic);
 using FrozenMapTypes =
-    testing::Types<std::map<int, int>, phmap::btree_map<int, int>>;
+    testing::Types<std::map<int, int>, dwarfs::internal::btree_map<int, int>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(
     FrozenAssociativeTest, FrozenMapBasic, FrozenMapTypes);
 
@@ -110,8 +110,8 @@ void testFrozenHashMapBasic() {
 
 TEST(FrozenHashMap, Basic) {
   testFrozenHashMapBasic<std::unordered_map<int, int>>();
-  testFrozenHashMapBasic<phmap::flat_hash_map<int, int>>();
-  testFrozenHashMapBasic<phmap::node_hash_map<int, int>>();
+  testFrozenHashMapBasic<dwarfs::internal::flat_hash_map<int, int>>();
+  testFrozenHashMapBasic<dwarfs::internal::node_hash_map<int, int>>();
 }
 
 TEST(FrozenHashMap, Iteration) {
@@ -253,7 +253,7 @@ TYPED_TEST_P(FrozenSetFull, Full) {
 
 REGISTER_TYPED_TEST_SUITE_P(FrozenSetFull, Full);
 using FrozenSetTypes =
-    testing::Types<std::set<uint32_t>, phmap::btree_set<uint32_t>>;
+    testing::Types<std::set<uint32_t>, dwarfs::internal::btree_set<uint32_t>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(
     FrozenAssociativeTest, FrozenSetFull, FrozenSetTypes);
 
@@ -284,8 +284,8 @@ void testFrozenHashSetFull() {
 
 TEST(FrozenHashSet, Full) {
   testFrozenHashSetFull<std::unordered_set<uint32_t>>();
-  testFrozenHashSetFull<phmap::flat_hash_set<uint32_t>>();
-  testFrozenHashSetFull<phmap::node_hash_set<uint32_t>>();
+  testFrozenHashSetFull<dwarfs::internal::flat_hash_set<uint32_t>>();
+  testFrozenHashSetFull<dwarfs::internal::node_hash_set<uint32_t>>();
 }
 
 TEST(Frozen, IntHashMapBig) {

--- a/frozen/thrift/lib/thrift/frozen.thrift
+++ b/frozen/thrift/lib/thrift/frozen.thrift
@@ -8,7 +8,7 @@
  * Marcus Holland-Moritz for use in dwarfs.
  */
 
-cpp_include "<parallel_hashmap/btree.h>"
+cpp_include "<dwarfs/internal/btree.h>"
 
 namespace cpp apache.thrift.frozen.schema
 
@@ -24,7 +24,7 @@ struct Field {
 struct Layout {
   1: i32 size;
   2: i16 bits;
-  3: map<i16, Field> fields (cpp.template = "phmap::btree_map");
+  3: map<i16, Field> fields (cpp.template = "dwarfs::internal::btree_map");
   4: string typeName;
 }
 
@@ -36,6 +36,6 @@ struct Schema {
   4: i32 fileVersion;
   // Field type names may not change unless relaxTypeChecks is set.
   1: bool relaxTypeChecks;
-  2: map<i16, Layout> layouts (cpp.template = "phmap::btree_map");
+  2: map<i16, Layout> layouts (cpp.template = "dwarfs::internal::btree_map");
   3: i16 rootLayout;
 }

--- a/include/dwarfs/internal/btree.h
+++ b/include/dwarfs/internal/btree.h
@@ -28,17 +28,33 @@
 
 #pragma once
 
-// NOLINTBEGIN(cppcoreguidelines-macro-to-enum)
-#cmakedefine DWARFS_HAVE_ABSEIL 1
-#cmakedefine DWARFS_HAVE_LIBMAGIC 1
-#cmakedefine DWARFS_HAVE_LIBLZ4 1
-#cmakedefine DWARFS_HAVE_LIBLZMA 1
-#cmakedefine DWARFS_HAVE_LIBBROTLI 1
-#cmakedefine DWARFS_HAVE_FLAC 1
-#cmakedefine DWARFS_HAVE_RICEPP 1
-#cmakedefine DWARFS_HAVE_LIBZSTD 1
-#cmakedefine DWARFS_BUILTIN_MANPAGE 1
-#cmakedefine DWARFS_PERFMON_ENABLED 1
-#cmakedefine DWARFS_STACKTRACE_ENABLED 1
-#cmakedefine DWARFS_FILESYSTEM_EXTRACTOR_NO_OPEN_FORMAT 1
-// NOLINTEND(cppcoreguidelines-macro-to-enum)
+#if __has_include(<dwarfs/config.h>)
+#include <dwarfs/config.h>
+#elif __has_include(<include/dwarfs/config.h>)
+#include <include/dwarfs/config.h>
+#endif
+
+#ifdef DWARFS_HAVE_ABSEIL
+
+#include <absl/container/btree_map.h>
+#include <absl/container/btree_set.h>
+
+namespace dwarfs::internal {
+
+using absl::btree_map;
+using absl::btree_set;
+
+} // namespace dwarfs::internal
+
+#else
+
+#include <parallel_hashmap/btree.h>
+
+namespace dwarfs::internal {
+
+using phmap::btree_map;
+using phmap::btree_set;
+
+} // namespace dwarfs::internal
+
+#endif

--- a/include/dwarfs/internal/phmap.h
+++ b/include/dwarfs/internal/phmap.h
@@ -1,0 +1,83 @@
+/* vim:set ts=2 sw=2 sts=2 et: */
+/**
+ * \author     Marcus Holland-Moritz (github@mhxnet.de)
+ * \copyright  Copyright (c) Marcus Holland-Moritz
+ *
+ * This file is part of dwarfs.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#if __has_include(<dwarfs/config.h>)
+#include <dwarfs/config.h>
+#elif __has_include(<include/dwarfs/config.h>)
+#include <include/dwarfs/config.h>
+#endif
+
+#ifdef DWARFS_HAVE_ABSEIL
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+
+#include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
+
+namespace dwarfs::internal {
+
+// absl::flat_hash_map<>::slot_type is private, so we need to define our own,
+// propagating the original template arguments.
+template <
+    class K, class V,
+    class Hash =
+        typename absl::container_internal::FlatHashMapPolicy<K, V>::DefaultHash,
+    class Eq =
+        typename absl::container_internal::FlatHashMapPolicy<K, V>::DefaultEq,
+    class Allocator = typename absl::container_internal::FlatHashMapPolicy<
+        K, V>::DefaultAlloc>
+class ABSL_ATTRIBUTE_OWNER flat_hash_map
+    : public absl::flat_hash_map<K, V, Hash, Eq, Allocator> {
+ public:
+  using slot_type =
+      typename absl::container_internal::FlatHashMapPolicy<K, V>::slot_type;
+};
+
+using absl::flat_hash_set;
+using absl::node_hash_map;
+using absl::node_hash_set;
+
+} // namespace dwarfs::internal
+
+#else
+
+#include <parallel_hashmap/phmap.h>
+
+namespace dwarfs::internal {
+
+using phmap::flat_hash_map;
+using phmap::flat_hash_set;
+using phmap::node_hash_map;
+using phmap::node_hash_set;
+
+} // namespace dwarfs::internal
+
+#endif

--- a/include/dwarfs/reader/internal/lru_cache.h
+++ b/include/dwarfs/reader/internal/lru_cache.h
@@ -32,7 +32,7 @@
 #include <iterator>
 #include <list>
 
-#include <parallel_hashmap/phmap.h>
+#include <dwarfs/internal/phmap.h>
 
 namespace dwarfs::reader::internal {
 
@@ -134,7 +134,7 @@ class lru_cache {
   }
 
   size_t max_size_;
-  phmap::flat_hash_map<key_type, iterator> index_;
+  dwarfs::internal::flat_hash_map<key_type, iterator> index_;
   std::list<value_type> cache_;
   prune_hook_type prune_hook_;
 };

--- a/include/dwarfs/writer/internal/global_entry_data.h
+++ b/include/dwarfs/writer/internal/global_entry_data.h
@@ -28,9 +28,8 @@
 #include <string>
 #include <vector>
 
-#include <parallel_hashmap/phmap.h>
-
 #include <dwarfs/file_stat.h>
+#include <dwarfs/internal/phmap.h>
 
 namespace dwarfs::thrift::metadata {
 class inode_data;
@@ -86,7 +85,7 @@ class global_entry_data {
 
  private:
   template <typename K, typename V>
-  using map_type = phmap::flat_hash_map<K, V>;
+  using map_type = dwarfs::internal::flat_hash_map<K, V>;
 
   template <typename T, typename U>
   std::vector<T> get_vector(map_type<T, U> const& map) const;

--- a/src/library_dependencies.cpp
+++ b/src/library_dependencies.cpp
@@ -37,10 +37,15 @@
 
 #include <boost/version.hpp>
 #include <openssl/crypto.h>
-#include <parallel_hashmap/phmap_config.h>
 #include <xxhash.h>
 
 #include <dwarfs/config.h>
+
+#ifdef DWARFS_HAVE_ABSEIL
+#include <absl/base/config.h>
+#else
+#include <parallel_hashmap/phmap_config.h>
+#endif
 
 #ifdef DWARFS_STACKTRACE_ENABLED
 #include <cpptrace/version.hpp>
@@ -117,8 +122,19 @@ void library_dependencies::add_common_libraries() {
   add_library("libfmt", FMT_VERSION, version_format::maj_min_patch_dec_100);
   add_library(fmt::format("crypto-{}", get_crypto_version()));
   add_library("libboost", BOOST_VERSION, version_format::boost);
+
+#ifdef DWARFS_HAVE_ABSEIL
+#ifdef ABSL_LTS_RELEASE_VERSION
+  add_library("abseil", fmt::format("{}.{}", ABSL_LTS_RELEASE_VERSION,
+                                    ABSL_LTS_RELEASE_PATCH_LEVEL));
+#else
+  add_library("abseil-head");
+#endif
+#else
   add_library("phmap", PHMAP_VERSION_MAJOR, PHMAP_VERSION_MINOR,
               PHMAP_VERSION_PATCH);
+#endif
+
 #ifdef DWARFS_STACKTRACE_ENABLED
   add_library("cpptrace", CPPTRACE_VERSION_MAJOR, CPPTRACE_VERSION_MINOR,
               CPPTRACE_VERSION_PATCH);

--- a/src/reader/internal/block_cache.cpp
+++ b/src/reader/internal/block_cache.cpp
@@ -41,8 +41,6 @@
 
 #include <fmt/format.h>
 
-#include <parallel_hashmap/phmap.h>
-
 #include <dwarfs/file_view.h>
 #include <dwarfs/logger.h>
 #include <dwarfs/performance_monitor.h>
@@ -52,6 +50,7 @@
 #include <dwarfs/util.h>
 
 #include <dwarfs/internal/fs_section.h>
+#include <dwarfs/internal/phmap.h>
 #include <dwarfs/internal/value_stream_quantile_estimator.h>
 #include <dwarfs/internal/worker_group.h>
 #include <dwarfs/reader/internal/block_cache.h>
@@ -772,7 +771,7 @@ class block_cache_ final : public block_cache::impl {
 
   using lru_type = lru_cache<size_t, std::shared_ptr<cached_block>>;
   template <typename Key, typename Value>
-  using fast_map_type = phmap::flat_hash_map<Key, Value>;
+  using fast_map_type = dwarfs::internal::flat_hash_map<Key, Value>;
 
   mutable std::mutex mx_;
   mutable lru_type cache_;

--- a/src/reader/internal/metadata_v2.cpp
+++ b/src/reader/internal/metadata_v2.cpp
@@ -48,8 +48,6 @@
 
 #include <dwarfs/portability/unistd.h>
 
-#include <parallel_hashmap/phmap.h>
-
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/transform.hpp>
 
@@ -69,6 +67,7 @@
 #include <dwarfs/internal/features.h>
 #include <dwarfs/internal/metadata_utils.h>
 #include <dwarfs/internal/packed_int_vector.h>
+#include <dwarfs/internal/phmap.h>
 #include <dwarfs/internal/string_table.h>
 #include <dwarfs/internal/synchronized.h>
 #include <dwarfs/internal/unicode_case_folding.h>
@@ -514,7 +513,7 @@ class metadata_v2_data {
 
  private:
   template <typename K>
-  using set_type = phmap::flat_hash_set<K>;
+  using set_type = dwarfs::internal::flat_hash_set<K>;
 
   int find_inode_offset(inode_rank rank) const {
     return find_inode_rank_offset(meta_, rank);
@@ -977,7 +976,8 @@ metadata_v2_data::build_dir_icase_cache(logger& lgr) const {
       });
 
       // Check and report any collisions in the directory
-      phmap::flat_hash_map<std::string_view, small_vector<uint32_t, 1>>
+      dwarfs::internal::flat_hash_map<std::string_view,
+                                      small_vector<uint32_t, 1>>
           collisions;
       collisions.reserve(range.size());
       for (size_t i = 0; i < names.size(); ++i) {

--- a/src/writer/internal/file_scanner.cpp
+++ b/src/writer/internal/file_scanner.cpp
@@ -31,8 +31,6 @@
 
 #include <nlohmann/json.hpp>
 
-#include <parallel_hashmap/phmap.h>
-
 #include <range/v3/view/drop.hpp>
 
 #include <dwarfs/checksum.h>
@@ -43,6 +41,7 @@
 #include <dwarfs/types.h>
 #include <dwarfs/util.h>
 
+#include <dwarfs/internal/phmap.h>
 #include <dwarfs/internal/worker_group.h>
 #include <dwarfs/writer/internal/entry.h>
 #include <dwarfs/writer/internal/file_scanner.h>
@@ -77,7 +76,7 @@ class file_scanner_ final : public file_scanner::impl {
 
  private:
   template <typename Key, typename Value>
-  using fast_map_type = phmap::flat_hash_map<Key, Value>;
+  using fast_map_type = dwarfs::internal::flat_hash_map<Key, Value>;
 
   void scan_dedupe(file* p);
   void hash_file(file* p);

--- a/src/writer/segmenter.cpp
+++ b/src/writer/segmenter.cpp
@@ -36,8 +36,6 @@
 
 #include <fmt/format.h>
 
-#include <parallel_hashmap/phmap.h>
-
 #include <dwarfs/compiler.h>
 #include <dwarfs/compression_constraints.h>
 #include <dwarfs/error.h>
@@ -50,6 +48,7 @@
 
 #include <dwarfs/internal/associative_vector_types.h>
 #include <dwarfs/internal/malloc_buffer.h>
+#include <dwarfs/internal/phmap.h>
 #include <dwarfs/internal/value_stream_quantile_estimator.h>
 #include <dwarfs/writer/internal/block_manager.h>
 #include <dwarfs/writer/internal/chunkable.h>
@@ -106,8 +105,8 @@ template <typename KeyT, typename ValT, size_t MaxCollInline = 2>
 class fast_multimap {
  private:
   using collision_vector = small_vector<ValT, MaxCollInline>;
-  using blockhash_t = phmap::flat_hash_map<KeyT, ValT>;
-  using collision_t = phmap::flat_hash_map<KeyT, collision_vector>;
+  using blockhash_t = dwarfs::internal::flat_hash_map<KeyT, ValT>;
+  using collision_t = dwarfs::internal::flat_hash_map<KeyT, collision_vector>;
 
  public:
   DWARFS_FORCE_INLINE void insert(KeyT const& key, ValT const& val) {
@@ -175,8 +174,8 @@ class fast_multimap {
   collision_t collisions_;
 };
 
-using repeating_sequence_map_type =
-    phmap::flat_hash_map<uint32_t, dwarfs::internal::small_vector_set<uint8_t>>;
+using repeating_sequence_map_type = dwarfs::internal::flat_hash_map<
+    uint32_t, dwarfs::internal::small_vector_set<uint8_t>>;
 using repeating_collisions_map_type = std::unordered_map<uint8_t, uint32_t>;
 
 /**

--- a/test/thrift_lite_codegen_roundtrip_test.cpp
+++ b/test/thrift_lite_codegen_roundtrip_test.cpp
@@ -95,7 +95,7 @@ static_assert(
     std::is_same_v<
         std::remove_cvref_t<
             decltype(std::declval<gen::Containers>().opt_map().value())>,
-        phmap::btree_map<std::int32_t, std::string>>,
+        dwarfs::internal::btree_map<std::int32_t, std::string>>,
     "unexpected type for Containers::opt_map");
 
 static_assert(
@@ -109,7 +109,7 @@ static_assert(
     std::is_same_v<
         std::remove_cvref_t<
             decltype(std::declval<gen::Containers>().opt_set().value())>,
-        phmap::btree_set<std::int32_t>>,
+        dwarfs::internal::btree_set<std::int32_t>>,
     "unexpected type for Containers::opt_set");
 
 TEST(thrift_lite_compact_roundtrip, terse_mode_everything_empty) {

--- a/test/thrift_lite_test.thrift
+++ b/test/thrift_lite_test.thrift
@@ -24,7 +24,7 @@
 namespace cpp dwarfs.thrift_lite.test
 
 cpp_include "<unordered_map>"
-cpp_include "<parallel_hashmap/btree.h>"
+cpp_include "<dwarfs/internal/btree.h>"
 
 // ---- Typedefs / cpp.type mapping ----
 
@@ -101,8 +101,8 @@ struct Containers {
 
   // Optional containers
   7: optional list<i64> opt_list
-  8: optional map<i32, string> opt_map (cpp.template = "phmap::btree_map")
-  9: optional set<i32> opt_set (cpp.template = "phmap::btree_set")
+  8: optional map<i32, string> opt_map (cpp.template = "dwarfs::internal::btree_map")
+  9: optional set<i32> opt_set (cpp.template = "dwarfs::internal::btree_set")
 }
 
 // ---- Forward/backward compat exercises ----


### PR DESCRIPTION
The classes from parallel-hashmap used in DwarFS are poor man's versions of the same classes from Abseil. Their only advantage is that they're header only and easy to use in any project. On the other hand,

* Abseil is actively developed (unlike parallel-hashmap, there's also GTL from the author of phmap which looks a bit more alive);
* `absl::Hash<>` is usually much faster and stronger than `std::hash<>` (depending on the STL library);
* Abseil has optional hardening (both production and debugging variants).

The fact that parallel-hashmap originally derived from Abseil makes these two almost drop-in/interchangeable replacements.

To not make DwarFS depend on more framework-like libraries, add an option to use Abseil it found and fits us. The "almost" mentioned above is due to that `absl::flat_hash_map<>::slot`_type is private, unlike phmap, where it's public and has a comment "TODO: make it private" ;)
So, in order to still be able to access `::slot_type`, we need to define a wrapper class which would expose it. There was a change in the container traits in Dec, 2025, so let's just test if the version we found contains this change and fall back to parallel-hashmap otherwise.

There's no usage of parallel-hashmap in the public DwarFS headers, so this won't go anywhere outside the library (and the wrappers can be placed to the internal/ include folder).
Also note that only Abseil LTS releases has version macros; Git/rolling version don't have any. Due to that,
`library_dependencies` will only print the actual version if an LTS is used and just "abseil-head" otherwise.

---

Tested libdwarfs using `dwarfs::reader::filesystem_v2` to index and read files from DwarFS archives containing game assets on Windows with the latest rolling Abseil (release/production hardening mode) and Clang/LLVM 22.

Note that there's another way to work around `::slot_type` -- it's used only to print some debugging info, so the corresponding DwFS code could be adjusted or cut a bit. This would allow to drop the wrapper class and use Abseil versions older than Dec, 2025 / LTS 202601, although I think this time gap is more than enough, especially given that it's an "advanced" option and the Abseil authors strongly recommend to use rolling/Git builds instead of LTSes anyway.

I realize this will inflate the CI/test matrix =\ We can default the option to `OFF`, mark as "experimental" or whatever, I'm perfectly fine with this. I just promoted my hack which used force includes to a proper integration/PR and wanted to share since it just works and may come handy at some point (I didn't benchmark the perf before/after, but Abseil containers are **really** fast).